### PR TITLE
Fix an error with the leftlabels option

### DIFF
--- a/titletoc.sty
+++ b/titletoc.sty
@@ -102,9 +102,10 @@
 \DeclareOption{rubberseps}{%
   \def\ttl@contentsstretch{\vskip\z@\@plus.1\p@}}
 
+\newcommand\contentslabel{}
 \DeclareOption{leftlabels}{%
   \renewcommand\numberline[1]{\hb@xt@\@tempdima{#1\ttl@idot\hfil}}%
-  \newcommand\contentslabel[2][\thecontentslabel\ttl@idot]{%
+  \renewcommand\contentslabel[2][\thecontentslabel\ttl@idot]{%
 %   \let\ttl@a\thecontentslabel   %%%%% For the star variant
 %   \def\thecontentslabel{#2}%    %%% To be fully implemented... when?
 %   \setbox\z@\hbox{#1}%
@@ -117,7 +118,7 @@
 \DeclareOption{rightlabels}{%
   \renewcommand\numberline[1]{\hb@xt@\@tempdima{\hss#1\ttl@idot\enspace}}%
   \let\contentslabel\relax
-  \newcommand\contentslabel[2][\thecontentslabel\ttl@idot\enspace]{%
+  \renewcommand\contentslabel[2][\thecontentslabel\ttl@idot\enspace]{%
     \hspace*{-#2}\hb@xt@#2{\hfil#1}}}
 
 \newcommand\contentspage[1][\thecontentspage]{%


### PR DESCRIPTION
[issues74](https://github.com/jbezos/titlesec/issues/74)  mentions that option `leftlabels` generates an error, so having the `\contentslabel` command created first and then redefined can solve this problem.